### PR TITLE
feat(web): 배변 날짜/시간 기록을 위한 폼 제작

### DIFF
--- a/web/src/app/(record)/defecation/_components/constants/index.ts
+++ b/web/src/app/(record)/defecation/_components/constants/index.ts
@@ -50,3 +50,7 @@ export const DEFECATION_TIME_TAKEN = {
   LESS_THAN_10_MINUTES: '10분 내',
   MORE_THAN_10_MINUTES: '10분 이상',
 } as const satisfies Record<string, string>;
+
+export const SCROLL_DELAY = 100;
+
+export const HOUR = 24;

--- a/web/src/app/(record)/defecation/_components/hooks/useScrollToSection.ts
+++ b/web/src/app/(record)/defecation/_components/hooks/useScrollToSection.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { SCROLL_DELAY } from '../constants';
+
+export const useScrollToSection = <T extends string>() => {
+  const refs = useRef<Partial<Record<T, HTMLDivElement | null>>>({});
+  const timerRef = useRef<number | null>(null);
+
+  const setRef = (key: T) => (el: HTMLDivElement | null) => {
+    refs.current[key] = el;
+  };
+
+  const scrollToSection = useCallback((key: T) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = window.setTimeout(() => {
+      const element = refs.current[key];
+      if (element) {
+        element.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+    }, SCROLL_DELAY);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    },
+    []
+  );
+
+  return { setRef, scrollToSection };
+};

--- a/web/src/app/(record)/defecation/_components/types/index.ts
+++ b/web/src/app/(record)/defecation/_components/types/index.ts
@@ -6,9 +6,8 @@ import type {
   DEFECATION_TIME_TAKEN,
 } from '../constants';
 
-/**
- * @description 배변 기록 폼 타입
- */ export interface DefecationState {
+// NOTE: 배변 기록 폼 타입
+export interface DefecationState {
   selectedWhen: Date;
   selectedTry: string;
   selectedColor: string;
@@ -18,37 +17,27 @@ import type {
   selectedOptional: string;
 }
 
-/**
- * @description 배변 기록 상세 타입
- */
+// NOTE: 배변 기록 상세 타입
 export type DefecationTryDetailKey = keyof typeof DEFECATION_DETAIL;
 export type DefecationTryDetailValue =
   (typeof DEFECATION_DETAIL)[DefecationTryDetailKey];
 
-/**
- * @description 배변 색상 타입
- */
+// NOTE: 배변 색상 타입
 export type DefecationTryColorKey = keyof typeof DEFECATION_COLOR;
 export type DefecationTryColorValue =
   (typeof DEFECATION_COLOR)[DefecationTryColorKey];
 
-/**
- * @description 배변 모양 타입
- */
+// NOTE: 배변 모양 타입
 export type DefecationTryShapeKey = keyof typeof DEFECATION_SHAPE;
 export type DefecationTryShapeValue =
   (typeof DEFECATION_SHAPE)[DefecationTryShapeKey];
 
-/**
- * @description 배변 통증 타입 (TODO: 통증 정도에 대한 디테일 작업은 UI 확정 후 변경 필요)
- */
+// NOTE: 배변 통증 타입 (TODO: 통증 정도에 대한 디테일 작업은 UI 확정 후 변경 필요)
 export type DefecationTryPainKey = keyof typeof DEFECATION_PAIN;
 export type DefecationTryPainValue =
   (typeof DEFECATION_PAIN)[DefecationTryPainKey];
 
-/**
- * @description 배변 소요 시간 타입
- */
+// NOTE: 배변 소요 시간 타입
 export type DefecationTryTimeTakenKey = keyof typeof DEFECATION_TIME_TAKEN;
 export type DefecationTryTimeTakenValue =
   (typeof DEFECATION_TIME_TAKEN)[DefecationTryTimeTakenKey];

--- a/web/src/app/(record)/defecation/_components/ui/defecation-detail.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/defecation-detail.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { DEFECATION_DETAIL } from '../constants';
+import { useScrollToSection } from '../hooks/useScrollToSection';
 import type { DefecationTryDetailKey } from '../types';
 import { CollapsibleToggle } from './common';
 import {
@@ -14,23 +15,41 @@ import {
 
 export const DefecationDetail = () => {
   const [openId, setOpenId] = useState<DefecationTryDetailKey | null>(null);
+  const { setRef, scrollToSection } =
+    useScrollToSection<DefecationTryDetailKey>();
+
+  const handleSectionChange = (id: DefecationTryDetailKey | null) => {
+    setOpenId(id);
+    if (id) {
+      scrollToSection(id);
+    }
+  };
 
   const handleToggle = (id: DefecationTryDetailKey) => {
-    setOpenId((prevId) => (prevId === id ? null : id));
+    const newOpenId = openId === id ? null : id;
+    handleSectionChange(newOpenId);
   };
 
   const renderSelectSection = (value: DefecationTryDetailKey) => {
     switch (value) {
       case 'COLOR':
-        return <DefecationColor onColorSelect={() => setOpenId('SHAPE')} />;
+        return (
+          <DefecationColor onColorSelect={() => handleSectionChange('SHAPE')} />
+        );
       case 'SHAPE':
-        return <DefecationShape onShapeSelect={() => setOpenId('PAIN')} />;
+        return (
+          <DefecationShape onShapeSelect={() => handleSectionChange('PAIN')} />
+        );
       case 'PAIN':
-        return <DefecationPain onPainSelect={() => setOpenId('TIME_TAKEN')} />;
+        return (
+          <DefecationPain
+            onPainSelect={() => handleSectionChange('TIME_TAKEN')}
+          />
+        );
       case 'TIME_TAKEN':
         return (
           <DefecationTimeTaken
-            onTimeTakenSelect={() => setOpenId('OPTIONAL')}
+            onTimeTakenSelect={() => handleSectionChange('OPTIONAL')}
           />
         );
       case 'OPTIONAL':
@@ -43,7 +62,7 @@ export const DefecationDetail = () => {
   return (
     <>
       {Object.entries(DEFECATION_DETAIL).map(([key, value]) => (
-        <div key={key}>
+        <div key={key} ref={setRef(key as DefecationTryDetailKey)}>
           <CollapsibleToggle
             id={key}
             isOpen={openId === key}

--- a/web/src/app/(record)/defecation/_components/ui/defecation-time.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/defecation-time.tsx
@@ -1,13 +1,111 @@
+'use client';
+
 import { ChevronDown } from 'lucide-react';
+import { type ChangeEvent, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { cn } from '@/utils/utils-cn';
+import type { DefecationFormValues } from '../schemas';
+import { formatDate, useHourOptions } from '../utils';
 
 export const DefecationTime = () => {
+  const { control } = useFormContext<DefecationFormValues>();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const hourOptions = useHourOptions();
+
   return (
-    <div className="flex flex-col items-start justify-center gap-2">
-      <p className="text-sm font-normal">배변 시각</p>
-      <div className="flex items-center gap-1">
-        <p className="text-xl font-bold">9월 4일 (목) 오후 15시</p>
-        <ChevronDown />
-      </div>
-    </div>
+    <Controller
+      name="selectedWhen"
+      control={control}
+      render={({ field }) => {
+        const currentDate =
+          field.value instanceof Date ? field.value : new Date();
+
+        const handleDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+          const { value } = e.target;
+
+          if (!value) return;
+
+          const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+          if (!dateRegex.test(value)) return;
+
+          const [year, month, day] = value.split('-').map(Number);
+          const newDate = new Date(currentDate);
+          newDate.setFullYear(year, month - 1, day);
+
+          if (Number.isNaN(newDate.getTime())) return;
+
+          field.onChange(newDate);
+        };
+
+        const handleHourChange = (hour: string) => {
+          const newDate = new Date(currentDate);
+          newDate.setHours(parseInt(hour, 10));
+          newDate.setMinutes(0);
+          newDate.setSeconds(0);
+          newDate.setMilliseconds(0);
+          field.onChange(newDate);
+        };
+
+        return (
+          <div className="flex flex-col items-start justify-center gap-2">
+            <p className="text-sm font-normal">배변 시각</p>
+            <button
+              className="flex items-center gap-1"
+              type="button"
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <p className="text-xl font-bold">{formatDate(currentDate)}</p>
+              <ChevronDown
+                className={cn(
+                  'transition-transform duration-300',
+                  isOpen ? 'rotate-180' : ''
+                )}
+              />
+            </button>
+
+            {isOpen && (
+              <div className="absolute z-10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-3/4 h-1/2 bg-[#17171C] border border-white rounded-lg p-4 flex flex-col gap-4">
+                <input
+                  type="date"
+                  className="bg-gray-700 text-white p-2 rounded"
+                  value={`${currentDate.getFullYear()}-${String(
+                    currentDate.getMonth() + 1
+                  ).padStart(2, '0')}-${String(currentDate.getDate()).padStart(
+                    2,
+                    '0'
+                  )}`}
+                  onChange={handleDateChange}
+                />
+                <div className="w-full flex items-center justify-start gap-2 overflow-x-auto">
+                  {hourOptions.map((option) => (
+                    <button
+                      type="button"
+                      key={option.id}
+                      className={cn(
+                        'flex items-center justify-center min-w-10 h-10 bg-[#454552] text-white rounded',
+                        currentDate.getHours() === parseInt(option.time, 10)
+                          ? 'bg-[#5170FF] text-white'
+                          : ''
+                      )}
+                      onClick={() => handleHourChange(option.time)}
+                    >
+                      {option.time}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="mt-auto bg-blue-500 text-white rounded-lg p-2"
+                  onClick={() => setIsOpen(false)}
+                >
+                  확인
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      }}
+    />
   );
 };

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/pain.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/pain.tsx
@@ -14,7 +14,7 @@ export default function Pain({ onPainSelect }: { onPainSelect?: () => void }) {
       <p className="text-sm font-medium opacity-80 mb-3.5">
         힘줄 때 느낀 고통은 어땠나요?
       </p>
-      <div className="flex flex-wrap gap-[11px]">
+      <div className="flex items-center justify-start gap-1">
         <Controller
           name="selectedPain"
           control={control}

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/shape.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/shape.tsx
@@ -6,10 +6,7 @@ import { cn } from '@/utils/utils-cn';
 import { DEFECATION_SHAPE } from '../../constants';
 import type { DefecationFormValues } from '../../schemas';
 import type { DefecationTryShapeKey } from '../../types';
-import {
-  getEmojiShapeIcon,
-  getRealShapeIcon,
-} from '../../utils/utils-getShapeIcon';
+import { getEmojiShapeIcon, getRealShapeIcon } from '../../utils';
 import { SelectButton, Switch } from '../common';
 
 export default function Shape({

--- a/web/src/app/(record)/defecation/_components/utils/index.ts
+++ b/web/src/app/(record)/defecation/_components/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './utils-formatDate';
+export * from './utils-generateHour';
+export * from './utils-getShapeIcon';

--- a/web/src/app/(record)/defecation/_components/utils/utils-formatDate.ts
+++ b/web/src/app/(record)/defecation/_components/utils/utils-formatDate.ts
@@ -1,0 +1,10 @@
+export const formatDate = (date: Date) => {
+  const datePart = new Intl.DateTimeFormat('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(date);
+  const hour = date.getHours();
+  const ampm = hour >= 12 ? '오후' : '오전';
+  return `${datePart} ${ampm} ${hour}시`;
+};

--- a/web/src/app/(record)/defecation/_components/utils/utils-generateHour.ts
+++ b/web/src/app/(record)/defecation/_components/utils/utils-generateHour.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { HOUR } from '../constants';
+
+export const useHourOptions = () => {
+  return useMemo(() => {
+    const options = [];
+    for (let i = 0; i < HOUR; i++) {
+      const value = i.toString().padStart(2, '0');
+      options.push({
+        id: i + 1,
+        time: value,
+      });
+    }
+    return options;
+  }, []);
+};

--- a/web/src/app/(record)/defecation/page.tsx
+++ b/web/src/app/(record)/defecation/page.tsx
@@ -11,10 +11,13 @@ export default function DefecationPage() {
       <div className="text-start space-y-6">
         {/* 배변 시간 선택 영역 */}
         <DefecationTime />
+
         {/* 배변 시도 기록 영역 */}
         <DefecationAttempt />
+
         {/* 배변 내용 상세 기록 영역 */}
         <DefecationDetail />
+
         {/* 저장 버튼 */}
         <DefecationSubmit />
       </div>


### PR DESCRIPTION
## 의도 🔍
- 배변 날짜, 시간을 기록하는 폼을 제작합니다.
- UX 향상을 위한 폼 이동 시 스크롤 상단을 돕는 훅을 생성합니다.


## 변경 사항 📝
- 달력 컴포넌트 및 타임 피커 부분은 UI 변동의 여지가 있어 브라우저 기본 제공 `<input type='date'/>` 를 활용해 임시로 구현했습니다.
- 스크롤 상단 이동을 위한 전역 커스텀 훅을 생성하여 폼 선택 후 다음 폼 이동 시 스크롤이 자연스럽게 올라가도록 했습니다.


## 작업 결과 📸 (Optional)

https://github.com/user-attachments/assets/0eecc1bf-7cf8-4d3a-a323-31f4bc4419ec




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 시간 선택 UI 강화: 날짜/시간 오버레이 선택, 시간 버튼, 폼 연동으로 입력 편의성 향상
  - 섹션 자동 스크롤: 색상 → 모양 → 통증 → 소요시간 이동 시 부드럽게 해당 위치로 이동
  - 기록 페이지 확장: 시도, 상세, 저장 섹션 추가로 입력 흐름 완성

- Style
  - 통증 선택 레이아웃 정렬 및 간격 개선으로 가독성 향상

- Refactor
  - 유틸 통합과 임포트 정리로 코드 일관성 및 유지보수성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->