### PR TITLE
fix(web):Yarn 4 + nodeLinker: node-modules 세팅

### DIFF
--- a/web/.yarnrc.yml
+++ b/web/.yarnrc.yml
@@ -1,1 +1,2 @@
+nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.9.4.cjs


### PR DESCRIPTION
## 의도 🔍
- 프로젝트의 패키지 매니저를 Yarn Berry(v4)로 마이그레이션한 이후, yarn dev 및 yarn build 실행 시 Next.js의 Turbopack에서 빌드가 실패 오류 확인
- 논의했던 대로  Yarn Berry의 패키지 연결자(nodeLinker) 설정을 변경하여 node_modules를 생성하도록 강제합니다.

### 오류 로그 
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/15447958-4ff5-415b-b623-d4d9bc80a54c" />

## 변경 사항 📝
```
.yarnrc.yml

nodeLinker: node-modules //추가
yarnPath: .yarn/releases/yarn-4.9.4.cjs
```
### 리뷰어들에게 👥
이 PR이 main 브랜치에 머지된 후, 모든 팀원은 원활한 개발 환경 동기화를 위해 아래의 과정을 로컬에서 진행해야 합니다.

1. Corepack 활성화 (PC에서 최초 한 번)
```
corepack enable
```
2. 최신 변경사항 반영 및 의존성 재설치

```
git pull origin main
rm -rf node_modules .yarn/install-state.gz
yarn install
```
3. 개발 서버 실행 확인

```
yarn dev
```

