### PR TITLE
feat(client): Button 공통 컴포넌트

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -45,12 +45,3 @@ body {
 ::-webkit-scrollbar {
   display: none;
 }
-
-/* 터치 디바이스 최적화 */
-@media (hover: none) and (pointer: coarse) {
-  button,
-  a {
-    min-height: 44px;
-    min-width: 44px;
-  }
-}

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -33,11 +33,11 @@ export const Button = ({
   ...rest
 }: ButtonProps) => {
   const sizeClasses = {
-    '56': 'py-[16px] px-[24px] text-button-2 rounded-[10px] gap-[4px]',
-    '48': 'py-[15px] px-[20px] text-button-2 rounded-[10px] gap-[4px]',
-    '40': 'py-[11px] px-[16px] text-button-2 rounded-[8px] gap-[4px]',
-    '32': 'py-[8px] px-[12px] text-button-4 rounded-[7px] gap-[2px]',
-    '24': 'py-[6px] px-[8px] text-button-4 rounded-[5px] gap-[2px]',
+    '56': 'py-4 px-6 text-button-2 rounded-[0.625rem] gap-1',
+    '48': 'py-[0.9375rem] px-5 text-button-2 rounded-[0.625rem] gap-1',
+    '40': 'py-[0.6875rem] px-4 text-button-2 rounded-[0.5rem] gap-1',
+    '32': 'py-2 px-3 text-button-4 rounded-[0.4375rem] gap-0.5',
+    '24': 'py-[0.375rem] px-2 text-button-4 rounded-[0.3125rem] gap-0.5',
   };
 
   const colorClasses = {

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,0 +1,67 @@
+import { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
+
+interface ButtonProps
+  extends PropsWithChildren,
+    ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: '56' | '48' | '40' | '32' | '24';
+  color?: 'primary' | 'secondary';
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+/**
+ * @param size
+ * @param color
+ * @param leftIcon
+ * @param rightIcon
+ * @param disabled
+ * @param fullWidth
+ * @returns
+ */
+export const Button = ({
+  children,
+  size = '48',
+  color = 'primary',
+  leftIcon,
+  rightIcon,
+  disabled = false,
+  fullWidth = false,
+  className = '',
+  ...rest
+}: ButtonProps) => {
+  const sizeClasses = {
+    '56': 'py-[16px] px-[24px] text-button-2 rounded-[10px] gap-[4px]',
+    '48': 'py-[15px] px-[20px] text-button-2 rounded-[10px] gap-[4px]',
+    '40': 'py-[11px] px-[16px] text-button-2 rounded-[8px] gap-[4px]',
+    '32': 'py-[8px] px-[12px] text-button-4 rounded-[7px] gap-[2px]',
+    '24': 'py-[6px] px-[8px] text-button-4 rounded-[5px] gap-[2px]',
+  };
+
+  const colorClasses = {
+    primary: disabled
+      ? 'bg-[#523e98] text-[#FFFFFF66]'
+      : 'bg-primary-600 text-white hover:bg-primary-800',
+    secondary: disabled
+      ? 'bg-gray-700 text-[#FFFFFF66]'
+      : 'bg-gray-800 text-white hover:bg-gray-800',
+  };
+
+  const baseClasses = `inline-flex items-center justify-center disabled:cursor-not-allowed ${
+    fullWidth ? 'w-full' : ''
+  }`;
+
+  return (
+    <button
+      className={`${baseClasses} ${sizeClasses[size]} ${colorClasses[color]} ${className}`}
+      disabled={disabled}
+      {...rest}
+    >
+      {leftIcon && <span className="flex-shrink-0">{leftIcon}</span>}
+      <span>{children}</span>
+      {rightIcon && <span className="flex-shrink-0">{rightIcon}</span>}
+    </button>
+  );
+};

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
+import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 
 interface ButtonProps
   extends PropsWithChildren,

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 interface ButtonProps
   extends PropsWithChildren,
@@ -21,47 +22,56 @@ interface ButtonProps
  * @param fullWidth
  * @returns
  */
-export const Button = ({
-  children,
-  size = '48',
-  color = 'primary',
-  leftIcon,
-  rightIcon,
-  disabled = false,
-  fullWidth = false,
-  className = '',
-  ...rest
-}: ButtonProps) => {
-  const sizeClasses = {
-    '56': 'py-4 px-6 text-button-2 rounded-[0.625rem] gap-1',
-    '48': 'py-[0.9375rem] px-5 text-button-2 rounded-[0.625rem] gap-1',
-    '40': 'py-[0.6875rem] px-4 text-button-2 rounded-[0.5rem] gap-1',
-    '32': 'py-2 px-3 text-button-4 rounded-[0.4375rem] gap-0.5',
-    '24': 'py-[0.375rem] px-2 text-button-4 rounded-[0.3125rem] gap-0.5',
-  };
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      size = '48',
+      color = 'primary',
+      leftIcon,
+      rightIcon,
+      disabled = false,
+      fullWidth = false,
+      className = '',
+      ...rest
+    },
+    ref
+  ) => {
+    const sizeClasses = {
+      '56': 'py-4 px-6 text-button-2 rounded-[0.625rem] gap-1',
+      '48': 'py-[0.9375rem] px-5 text-button-2 rounded-[0.625rem] gap-1',
+      '40': 'py-[0.6875rem] px-4 text-button-2 rounded-[0.5rem] gap-1',
+      '32': 'py-2 px-3 text-button-4 rounded-[0.4375rem] gap-0.5',
+      '24': 'py-[0.375rem] px-2 text-button-4 rounded-[0.3125rem] gap-0.5',
+    };
 
-  const colorClasses = {
-    primary: disabled
-      ? 'bg-[#523e98] text-[#FFFFFF66]'
-      : 'bg-primary-600 text-white hover:bg-primary-800',
-    secondary: disabled
-      ? 'bg-gray-700 text-[#FFFFFF66]'
-      : 'bg-gray-800 text-white hover:bg-gray-800',
-  };
+    const colorClasses = {
+      primary: disabled
+        ? 'bg-[#523e98] text-[#FFFFFF66]'
+        : 'bg-primary-600 text-white hover:bg-primary-800',
+      secondary: disabled
+        ? 'bg-gray-700 text-[#FFFFFF66]'
+        : 'bg-gray-800 text-white hover:bg-gray-800',
+    };
 
-  const baseClasses = `inline-flex items-center justify-center disabled:cursor-not-allowed ${
-    fullWidth ? 'w-full' : ''
-  }`;
+    const baseClasses = `inline-flex items-center justify-center disabled:cursor-not-allowed focus:outline-none focus-visible:outline-none ${
+      fullWidth ? 'w-full' : ''
+    }`;
 
-  return (
-    <button
-      className={`${baseClasses} ${sizeClasses[size]} ${colorClasses[color]} ${className}`}
-      disabled={disabled}
-      {...rest}
-    >
-      {leftIcon && <span className="flex-shrink-0">{leftIcon}</span>}
-      <span>{children}</span>
-      {rightIcon && <span className="flex-shrink-0">{rightIcon}</span>}
-    </button>
-  );
-};
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={`${baseClasses} ${sizeClasses[size]} ${colorClasses[color]} ${className}`}
+        disabled={disabled}
+        {...rest}
+      >
+        {leftIcon && <span className="flex-shrink-0">{leftIcon}</span>}
+        <span>{children}</span>
+        {rightIcon && <span className="flex-shrink-0">{rightIcon}</span>}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Button'

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -1,1 +1,1 @@
-export * from './Button'
+export * from './Button';


### PR DESCRIPTION
## 의도 🔍
<!-- 해당 작업을 왜 하게 되었는지 이유를 작성합니다. -->
<!-- PRD 문서, 아사나, Figma, 노션, 슬랙 등의 컨텍스트가 있다면 링크를 첨부합니다. -->
 
- Button 공통 컴포넌트 제작합니다.

## 변경 사항 📝
<!-- 해당 작업이 어떤 변경사항을 포함하고 있는지 작성합니다. 변경사항이 의도에 포함되었다면 생략해도 됩니다. -->


## 작업 결과 📸 (Optional)
<!-- 변경 사항이 정상적으로 작동하는지 나타낼 수 있는 스크린샷이나 API 응답 등을 첨부합니다. -->

<img width="432" height="260" alt="image" src="https://github.com/user-attachments/assets/e9d9b7f7-2b38-48a1-8dc9-453afa2f947e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 버튼 컴포넌트를 추가했습니다. 다양한 크기(56/48/40/32/24)와 색상(기본/보조)을 지원하며, 비활성화, 전체 너비 옵션, 좌/우 아이콘 슬롯을 제공하고 기본 버튼 속성 전달을 통해 기존 사용성과 호환됩니다.
- 작업
  - 컴포넌트 집합의 일관된 내보내기 진입점을 추가해 버튼을 한 곳에서 가져올 수 있도록 가져오기 경로를 단순화했습니다.
- 스타일
  - 터치 디바이스 최적화용 최소 버튼/링크 크기 관련 CSS 블록을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->