### PR TITLE
feat(web): 상단 네비게이션, 하단 등록 버튼 공통 컴포넌트 작업

### DIFF
--- a/web/src/app/(record)/defecation/_components/ui/defecation-submit.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/defecation-submit.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { type FieldErrors, useFormContext } from 'react-hook-form';
+import { BottomBtnBar } from '@/components';
 import type { DefecationFormValues } from '../schemas';
 
 export const DefecationSubmit = () => {
@@ -18,13 +19,5 @@ export const DefecationSubmit = () => {
     alert(`${firstError} 필드를 확인해주세요.`);
   };
 
-  return (
-    <button
-      type="button"
-      className="w-full bg-blue-500 text-white rounded-lg p-2"
-      onClick={handleSubmit(onSubmit, onError)}
-    >
-      저장
-    </button>
-  );
+  return <BottomBtnBar onSubmit={handleSubmit(onSubmit, onError)} />;
 };

--- a/web/src/app/(record)/defecation/layout.tsx
+++ b/web/src/app/(record)/defecation/layout.tsx
@@ -1,12 +1,20 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { Navigator } from '@/components';
 import { DefecationProvider } from './_components/providers/defecation-providers';
+import { DefecationSubmit } from './_components/ui';
 
 export default function DefecationLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  return <DefecationProvider>{children}</DefecationProvider>;
+  return (
+    <DefecationProvider>
+      <Navigator title="배변 기록" />
+      {children}
+      <DefecationSubmit />
+    </DefecationProvider>
+  );
 }

--- a/web/src/app/(record)/defecation/page.tsx
+++ b/web/src/app/(record)/defecation/page.tsx
@@ -1,13 +1,12 @@
 import {
   DefecationAttempt,
   DefecationDetail,
-  DefecationSubmit,
   DefecationTime,
 } from './_components/ui';
 
 export default function DefecationPage() {
   return (
-    <div className="min-h-screen bg-[#17171C] text-white px-4 pt-17 pb-12 select-none">
+    <div className="min-h-screen bg-gray-900 text-white px-4 pt-17 pb-[calc(120px+36px)] select-none">
       <div className="text-start space-y-6">
         {/* 배변 시간 선택 영역 */}
         <DefecationTime />
@@ -17,9 +16,6 @@ export default function DefecationPage() {
 
         {/* 배변 내용 상세 기록 영역 */}
         <DefecationDetail />
-
-        {/* 저장 버튼 */}
-        <DefecationSubmit />
       </div>
     </div>
   );

--- a/web/src/app/(record)/defecation/page.tsx
+++ b/web/src/app/(record)/defecation/page.tsx
@@ -1,22 +1,22 @@
 import {
-	DefecationAttempt,
-	DefecationDetail,
-	DefecationTime,
-} from "./_components/ui";
+  DefecationAttempt,
+  DefecationDetail,
+  DefecationTime,
+} from './_components/ui';
 
 export default function DefecationPage() {
-	return (
-		<div className="min-h-screen bg-gray-900 text-white px-4 pt-17 pb-[156px] select-none">
-			<div className="text-start space-y-6">
-				{/* 배변 시간 선택 영역 */}
-				<DefecationTime />
+  return (
+    <div className="min-h-screen bg-gray-900 text-white px-4 pt-17 pb-[156px] select-none">
+      <div className="text-start space-y-6">
+        {/* 배변 시간 선택 영역 */}
+        <DefecationTime />
 
-				{/* 배변 시도 기록 영역 */}
-				<DefecationAttempt />
+        {/* 배변 시도 기록 영역 */}
+        <DefecationAttempt />
 
-				{/* 배변 내용 상세 기록 영역 */}
-				<DefecationDetail />
-			</div>
-		</div>
-	);
+        {/* 배변 내용 상세 기록 영역 */}
+        <DefecationDetail />
+      </div>
+    </div>
+  );
 }

--- a/web/src/app/(record)/defecation/page.tsx
+++ b/web/src/app/(record)/defecation/page.tsx
@@ -1,22 +1,22 @@
 import {
-  DefecationAttempt,
-  DefecationDetail,
-  DefecationTime,
-} from './_components/ui';
+	DefecationAttempt,
+	DefecationDetail,
+	DefecationTime,
+} from "./_components/ui";
 
 export default function DefecationPage() {
-  return (
-    <div className="min-h-screen bg-gray-900 text-white px-4 pt-17 pb-[calc(120px+36px)] select-none">
-      <div className="text-start space-y-6">
-        {/* 배변 시간 선택 영역 */}
-        <DefecationTime />
+	return (
+		<div className="min-h-screen bg-gray-900 text-white px-4 pt-17 pb-[156px] select-none">
+			<div className="text-start space-y-6">
+				{/* 배변 시간 선택 영역 */}
+				<DefecationTime />
 
-        {/* 배변 시도 기록 영역 */}
-        <DefecationAttempt />
+				{/* 배변 시도 기록 영역 */}
+				<DefecationAttempt />
 
-        {/* 배변 내용 상세 기록 영역 */}
-        <DefecationDetail />
-      </div>
-    </div>
-  );
+				{/* 배변 내용 상세 기록 영역 */}
+				<DefecationDetail />
+			</div>
+		</div>
+	);
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -36,6 +36,15 @@ export default function Home() {
                   알림 테스트 페이지
                 </Link>
               </li>
+              <li>
+                •{' '}
+                <Link
+                  href="/defecation"
+                  className="text-green-600 hover:text-green-800 underline transition-colors"
+                >
+                  배변 기록 페이지
+                </Link>
+              </li>
             </ul>
           </div>
         </div>

--- a/web/src/components/BottomBtnBar.tsx
+++ b/web/src/components/BottomBtnBar.tsx
@@ -1,0 +1,17 @@
+import { Button } from './Button';
+
+export const BottomBtnBar = ({
+  text = '등록',
+  onSubmit,
+}: {
+  text?: string;
+  onSubmit: () => void;
+}) => {
+  return (
+    <div className="fixed bottom-0 left-0 w-full h-30 z-10 pt-4 px-4 bg-gray-900">
+      <Button size="56" color="primary" fullWidth onClick={onSubmit}>
+        <p>{text}</p>
+      </Button>
+    </div>
+  );
+};

--- a/web/src/components/Navigator.tsx
+++ b/web/src/components/Navigator.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+export const Navigator = ({ title }: { title: string }) => {
+  const router = useRouter();
+
+  return (
+    <div className="fixed top-0 left-0 w-full h-[56px] bg-gray-900 text-white p-4 flex shrink-0 justify-between">
+      <ArrowLeft className="w-6 h-6" onClick={() => router.back()} />
+      <p className="text-h3">{title}</p>
+      <div className="w-6 h-6" />
+    </div>
+  );
+};

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -1,1 +1,3 @@
+export * from './BottomBtnBar';
 export * from './Button';
+export * from './Navigator';

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -9,7 +9,7 @@ module.exports = {
       fontSize: {
         h1: ['1.75rem', { lineHeight: '130%', fontWeight: '600' }],
         h2: ['1.5rem', { lineHeight: '135%', fontWeight: '600' }],
-        h3: ['1.25rem', { lineHeight: '135%', fontWeight: '600' }],
+        h3: ['1.125rem', { lineHeight: '135%', fontWeight: '600' }],
         h4: ['1rem', { lineHeight: '150%', fontWeight: '600' }],
         'body1-r': ['1.125rem', { lineHeight: '135%', fontWeight: '400' }],
         'body1-m': ['1.125rem', { lineHeight: '130%', fontWeight: '500' }],


### PR DESCRIPTION
## 의도 🔍
상단 네비게이션바와 하단 등록 버튼 컴포넌트를 공통 컴포넌트로 작업했습니다.


## 변경 사항 📝
- Navigator.tsx 상단 네비게이션 컴포넌트
- BottomBtnBar.tsx 하단 등록 버튼 컴포넌트
- `/defecation/layout.tsx` 참고하셔서 작업하시면 될 것 같습니다!


## 작업 결과 📸 (Optional)
<img width="376" height="818" alt="스크린샷 2025-09-14 00 55 56" src="https://github.com/user-attachments/assets/3c2601ad-906e-45e4-ab26-37e162685ff1" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 배변 기록에 상단 내비게이션 바(뒤로가기·제목) 추가
  - 하단 고정 등록 버튼 바 도입으로 손쉬운 제출 제공
  - 홈 화면에 “배변 기록 페이지” 바로가기 링크 추가
- 리팩터링
  - 제출 동작을 하단 버튼 바로 일원화해 페이지 전반에서 일관된 사용성 제공
- 스타일
  - 페이지 배경을 더 어두운 톤으로 조정하고 하단 패딩 확대하여 버튼과 콘텐츠 겹침 방지
  - h3 글자 크기 소폭 축소로 가독성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->