### PR TITLE
feat(web): ios notification (3) - ios 로컬/서버 푸시 구현

### DIFF
--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    message: '서버가 정상적으로 작동 중입니다.',
+  });
+}

--- a/web/src/app/api/send-push/route.ts
+++ b/web/src/app/api/send-push/route.ts
@@ -20,7 +20,7 @@ async function sendExpoPushNotification(
     };
 
     console.log('📤 Expo Push 메시지 전송 시도:', {
-      token: token.substring(0, 20) + '...',
+      token: `${token.substring(0, 20)}...`,
       title,
       body,
     });
@@ -28,7 +28,7 @@ async function sendExpoPushNotification(
     const response = await fetch('https://exp.host/--/api/v2/push/send', {
       method: 'POST',
       headers: {
-        'Accept': 'application/json',
+        Accept: 'application/json',
         'Accept-encoding': 'gzip, deflate',
         'Content-Type': 'application/json',
       },
@@ -51,7 +51,6 @@ async function sendExpoPushNotification(
 
 export async function POST(request: NextRequest) {
   try {
-
     const { title, body, targetToken } = await request.json();
 
     if (!title || !body) {

--- a/web/src/app/api/send-push/route.ts
+++ b/web/src/app/api/send-push/route.ts
@@ -1,98 +1,56 @@
-import type { ServiceAccount } from 'firebase-admin';
-import * as admin from 'firebase-admin';
 import { type NextRequest, NextResponse } from 'next/server';
 
-// NOTE(seonghyun): Firebase Admin SDK 초기화
-let firebaseInitialized = false;
-
-function initializeFirebase() {
-  if (firebaseInitialized || admin.apps.length > 0) {
-    return;
-  }
-
-  // NOTE(seonghyun): 환경변수에서 서비스 계정 정보 가져오기
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-
-  if (!projectId || !privateKey || !clientEmail) {
-    console.warn(
-      'Firebase 환경변수가 설정되지 않았습니다. 푸시 알림 기능이 비활성화됩니다.'
-    );
-    firebaseInitialized = true;
-    return;
-  }
-
-  const serviceAccount = {
-    projectId,
-    privateKey,
-    clientEmail,
-  } as ServiceAccount;
-
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount),
-  });
-
-  firebaseInitialized = true;
-}
-
-// NOTE(seonghyun): Firebase Cloud Messaging을 사용하여 알림 전송
-async function sendFCMPushNotification(
+// NOTE(seonghyun): Expo Push API를 사용하여 알림 전송
+async function sendExpoPushNotification(
   token: string,
   title: string,
   body: string
 ) {
   try {
     const message = {
-      token,
-      notification: {
-        title,
-        body,
-      },
+      to: token,
+      title,
+      body,
+      sound: 'default',
       data: {
         title,
         body,
         timestamp: new Date().toISOString(),
       },
-      android: {
-        notification: {
-          sound: 'default',
-        },
-      },
-      apns: {
-        payload: {
-          aps: {
-            sound: 'default',
-          },
-        },
-      },
     };
 
-    const response = await admin.messaging().send(message);
-    return { success: true, messageId: response };
+    console.log('📤 Expo Push 메시지 전송 시도:', {
+      token: token.substring(0, 20) + '...',
+      title,
+      body,
+    });
+
+    const response = await fetch('https://exp.host/--/api/v2/push/send', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Accept-encoding': 'gzip, deflate',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      throw new Error(`Expo Push API 오류: ${response.status} - ${errorData}`);
+    }
+
+    const result = await response.json();
+    console.log('✅ Expo Push 메시지 전송 성공:', result);
+    return { success: true, result };
   } catch (error) {
-    console.error('FCM Push 전송 오류:', error);
+    console.error('❌ Expo Push 전송 오류:', error);
     throw error;
   }
 }
 
 export async function POST(request: NextRequest) {
   try {
-    // Firebase 초기화 시도
-    initializeFirebase();
-
-    // Firebase가 초기화되지 않은 경우 (환경변수 없음)
-    if (!admin.apps.length) {
-      return NextResponse.json(
-        {
-          error:
-            'Firebase 환경변수가 설정되지 않았습니다. 푸시 알림 기능을 사용할 수 없습니다.',
-          details:
-            'FIREBASE_PROJECT_ID, FIREBASE_PRIVATE_KEY, FIREBASE_CLIENT_EMAIL 환경변수를 설정해주세요.',
-        },
-        { status: 503 }
-      );
-    }
 
     const { title, body, targetToken } = await request.json();
 
@@ -130,7 +88,7 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const result = await sendFCMPushNotification(targetToken, title, body);
+      const result = await sendExpoPushNotification(targetToken, title, body);
       results.push({
         token: targetToken,
         deviceName: targetDevice.deviceName,
@@ -140,7 +98,7 @@ export async function POST(request: NextRequest) {
       // NOTE(seonghyun): 모든 등록된 토큰에 전송
       for (const tokenData of tokens) {
         try {
-          const result = await sendFCMPushNotification(
+          const result = await sendExpoPushNotification(
             tokenData.token,
             title,
             body

--- a/web/src/constants/route.constants.ts
+++ b/web/src/constants/route.constants.ts
@@ -14,4 +14,4 @@ export const API_ROUTES = {
 } as const;
 
 // 공개 경로 (인증이 필요하지 않은 경로)
-export const PUBLIC_PATHS = ['/', '/auth'] as const;
+export const PUBLIC_PATHS = ['/', '/auth', '/notification-test'] as const;


### PR DESCRIPTION
## 의도 🔍
- ios 로컬/서버 푸시 구현가 가능하도록 web 에서 구현합니다.


## 작업 결과 📸 (Optional)

https://github.com/user-attachments/assets/e3f39d10-1dd9-4632-a1c4-e7191cb6e3a0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림 테스트 페이지(/notification-test)를 공개 경로에 추가하여 로그인 없이 접근 가능합니다.
- 리팩터링
  - 푸시 알림 전송 방식을 Expo Push 기반으로 전환하여 전송 성공률과 오류 가시성을 개선했습니다. 개별 토큰별 전송 결과를 더 명확히 확인할 수 있습니다.
- 작업(Chores)
  - 시스템 상태 확인을 위한 헬스 체크 API 엔드포인트를 추가했습니다. 서비스 동작 상태와 타임스탬프를 확인할 수 있어 운영 모니터링이 용이해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->