### PR TITLE
feat(web): BottomNavigation 컴포넌트 구현

### DIFF
--- a/web/src/app/home/_components/ui/BottomNavigation.tsx
+++ b/web/src/app/home/_components/ui/BottomNavigation.tsx
@@ -1,0 +1,66 @@
+import { Calendar, Home as HomeIcon, NotepadText, User } from 'lucide-react';
+import type { RefObject } from 'react';
+import { cn } from '@/utils/utils-cn';
+import type { Tab } from '../../types';
+
+const BOTTOM_NAV_TABS = [
+  {
+    id: 'home' as const,
+    name: '홈',
+    icon: HomeIcon,
+  },
+  {
+    id: 'calendar' as const,
+    name: '캘린더',
+    icon: Calendar,
+  },
+  {
+    id: 'report' as const,
+    name: '리포트',
+    icon: NotepadText,
+  },
+  {
+    id: 'my' as const,
+    name: '마이',
+    icon: User,
+  },
+];
+
+type BottomNavigationProps = {
+  navRef: RefObject<HTMLElement | null>;
+  onTabClick: (tabName: Tab) => void;
+  currentTab: Tab;
+};
+
+const BottomNavigation = ({
+  navRef,
+  onTabClick,
+  currentTab,
+}: BottomNavigationProps) => {
+  return (
+    <nav ref={navRef} className="bg-gray-900 fixed bottom-0 border-none w-full">
+      <div className="flex justify-between">
+        {BOTTOM_NAV_TABS.map((tab) => {
+          const IconComponent = tab.icon;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              className="py-[1.19rem] pl-[1.78rem] pr-[1.84rem] cursor-pointer flex flex-col items-center gap-1 bg-transparent border-none text-white"
+              onClick={() => onTabClick(tab.id)}
+            >
+              <IconComponent
+                className={cn(
+                  currentTab === tab.id ? 'text-white' : 'text-gray-500'
+                )}
+              />
+              {tab.name}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};
+
+export default BottomNavigation;

--- a/web/src/app/home/_components/ui/RecordSection.tsx
+++ b/web/src/app/home/_components/ui/RecordSection.tsx
@@ -4,6 +4,10 @@ import ChevronLeft from '@/assets/home/IC_Chevron_Left.png';
 import ChevronRight from '@/assets/home/IC_Chevron_Right.png';
 import { cn } from '@/utils/utils-cn';
 import { formatDate, isNextDisabled, isPrevDisabled } from '../utils/util-date';
+<<<<<<< HEAD
+=======
+import { getRecordPath } from '../utils/util-route';
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
 type RecordSectionProps = {
   navHeight: number;
@@ -21,11 +25,19 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
     }
     setSelectedDate(newDate);
   };
+<<<<<<< HEAD
   // NOTE(yubin): RecordButton 브렌치 병합시 주석해제
   // const handleRecordClick = (type: 'defecation' | 'lifestyle') => {
   //   const path = getRecordPath(type, selectedDate);
   //   router.push(path);
   // };
+=======
+
+  const _handleRecordClick = (type: 'defecation' | 'lifestyle') => {
+    const path = getRecordPath(type, selectedDate);
+    router.push(path);
+  };
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
   return (
     <section
@@ -63,8 +75,24 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
           />
         </button>
       </div>
+      {/* RecordButton 컴포넌트는 record-button 브랜치에서 관리됩니다 */}
       <div className="flex gap-[0.69rem] mt-4">
+<<<<<<< HEAD
         {/* NOTE(yubin): RecordButton 컴포넌트 추가  */}
+=======
+        <div className="flex items-start bg-gray-800 flex-1 p-[1.12rem] rounded-[0.875rem] text-body3-r">
+          <div className="text-left flex flex-col flex-1">
+            <div className="text-gray-400">이날의 뿡</div>
+            <div className="text-body1-sb">배변 기록하기</div>
+          </div>
+        </div>
+        <div className="flex items-start bg-gray-800 flex-1 p-[1.12rem] rounded-[0.875rem] text-body3-r">
+          <div className="text-left flex flex-col flex-1">
+            <div className="text-gray-400">이날의 냠</div>
+            <div className="text-body1-sb">생활 기록하기</div>
+          </div>
+        </div>
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
       </div>
     </section>
   );

--- a/web/src/app/home/_components/ui/RecordSection.tsx
+++ b/web/src/app/home/_components/ui/RecordSection.tsx
@@ -4,10 +4,6 @@ import ChevronLeft from '@/assets/home/IC_Chevron_Left.png';
 import ChevronRight from '@/assets/home/IC_Chevron_Right.png';
 import { cn } from '@/utils/utils-cn';
 import { formatDate, isNextDisabled, isPrevDisabled } from '../utils/util-date';
-<<<<<<< HEAD
-=======
-import { getRecordPath } from '../utils/util-route';
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
 type RecordSectionProps = {
   navHeight: number;
@@ -25,19 +21,6 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
     }
     setSelectedDate(newDate);
   };
-<<<<<<< HEAD
-  // NOTE(yubin): RecordButton 브렌치 병합시 주석해제
-  // const handleRecordClick = (type: 'defecation' | 'lifestyle') => {
-  //   const path = getRecordPath(type, selectedDate);
-  //   router.push(path);
-  // };
-=======
-
-  const _handleRecordClick = (type: 'defecation' | 'lifestyle') => {
-    const path = getRecordPath(type, selectedDate);
-    router.push(path);
-  };
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
   return (
     <section
@@ -75,24 +58,8 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
           />
         </button>
       </div>
-      {/* RecordButton 컴포넌트는 record-button 브랜치에서 관리됩니다 */}
       <div className="flex gap-[0.69rem] mt-4">
-<<<<<<< HEAD
         {/* NOTE(yubin): RecordButton 컴포넌트 추가  */}
-=======
-        <div className="flex items-start bg-gray-800 flex-1 p-[1.12rem] rounded-[0.875rem] text-body3-r">
-          <div className="text-left flex flex-col flex-1">
-            <div className="text-gray-400">이날의 뿡</div>
-            <div className="text-body1-sb">배변 기록하기</div>
-          </div>
-        </div>
-        <div className="flex items-start bg-gray-800 flex-1 p-[1.12rem] rounded-[0.875rem] text-body3-r">
-          <div className="text-left flex flex-col flex-1">
-            <div className="text-gray-400">이날의 냠</div>
-            <div className="text-body1-sb">생활 기록하기</div>
-          </div>
-        </div>
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
       </div>
     </section>
   );

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,23 +1,3 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 export { default as BottomNavigation } from './BottomNavigation';
-<<<<<<< HEAD
 export { default as RecordButton } from './RecordButton';
->>>>>>> c754ef7 (feat: BottomNavigation 컴포넌트 구현)
-=======
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
-=======
-=======
->>>>>>> 6e29818 (feat: BottomNavigation 컴포넌트 구현)
-export { default as BottomNavigation } from './BottomNavigation';
-=======
->>>>>>> 12ce55f (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
->>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 export { default as RecordSection } from './RecordSection';
-=======
-export { default as BottomNavigation } from "./BottomNavigation";
-export { default as RecordButton } from "./RecordButton";
-export { default as RecordSection } from "./RecordSection";
->>>>>>> 91e1240 (feat: BottomNavigation 컴포넌트 구현)

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 export { default as BottomNavigation } from './BottomNavigation';
 <<<<<<< HEAD
@@ -6,4 +7,9 @@ export { default as RecordButton } from './RecordButton';
 >>>>>>> c754ef7 (feat: BottomNavigation 컴포넌트 구현)
 =======
 >>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
+=======
+export { default as BottomNavigation } from './BottomNavigation';
+=======
+>>>>>>> 12ce55f (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
+>>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 export { default as RecordSection } from './RecordSection';

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,6 +1,9 @@
 <<<<<<< HEAD
 =======
 export { default as BottomNavigation } from './BottomNavigation';
+<<<<<<< HEAD
 export { default as RecordButton } from './RecordButton';
 >>>>>>> c754ef7 (feat: BottomNavigation 컴포넌트 구현)
+=======
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 export { default as RecordSection } from './RecordSection';

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,3 +1,2 @@
 export { default as BottomNavigation } from './BottomNavigation';
-export { default as RecordButton } from './RecordButton';
 export { default as RecordSection } from './RecordSection';

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,1 +1,6 @@
+<<<<<<< HEAD
+=======
+export { default as BottomNavigation } from './BottomNavigation';
+export { default as RecordButton } from './RecordButton';
+>>>>>>> c754ef7 (feat: BottomNavigation 컴포넌트 구현)
 export { default as RecordSection } from './RecordSection';

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,5 +1,6 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 export { default as BottomNavigation } from './BottomNavigation';
 <<<<<<< HEAD
@@ -8,8 +9,15 @@ export { default as RecordButton } from './RecordButton';
 =======
 >>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 =======
+=======
+>>>>>>> 6e29818 (feat: BottomNavigation 컴포넌트 구현)
 export { default as BottomNavigation } from './BottomNavigation';
 =======
 >>>>>>> 12ce55f (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 >>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 export { default as RecordSection } from './RecordSection';
+=======
+export { default as BottomNavigation } from "./BottomNavigation";
+export { default as RecordButton } from "./RecordButton";
+export { default as RecordSection } from "./RecordSection";
+>>>>>>> 91e1240 (feat: BottomNavigation 컴포넌트 구현)

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { Bell } from 'lucide-react';
 import Image from 'next/image';
 <<<<<<< HEAD
@@ -13,13 +14,19 @@ import { BottomNavigation } from './_components/ui';
 import type { Tab } from './types';
 import MaskGroup from '@/assets/home/Mask group.svg';
 =======
+=======
+// biome-ignore assist/source/organizeImports: <explanation></explanation>
+>>>>>>> e6c6a31 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 import { Bell } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import MaskGroup from "@/assets/home/Mask group.svg";
 import { BottomNavigation } from "./_components/ui";
 import type { Tab } from "./types";
+<<<<<<< HEAD
 >>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
+=======
+import MaskGroup from "@/assets/home/Mask group.svg";
+>>>>>>> e6c6a31 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
 export default function Home() {
 	const [activeTab, setActiveTab] = useState<Tab>("home");

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -1,91 +1,38 @@
-"use client";
+'use client';
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { Bell } from 'lucide-react';
 import Image from 'next/image';
-<<<<<<< HEAD
-import MaskGroup from '@/assets/home/Mask group.svg';
-
-export default function Home() {
-=======
 import { useEffect, useRef, useState } from 'react';
+import MaskGroup from '@/assets/home/Mask group.svg';
 import { BottomNavigation } from './_components/ui';
 import type { Tab } from './types';
-import MaskGroup from '@/assets/home/Mask group.svg';
-=======
-=======
-// biome-ignore assist/source/organizeImports: <explanation></explanation>
->>>>>>> e6c6a31 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
-import { Bell } from "lucide-react";
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-import { BottomNavigation } from "./_components/ui";
-import type { Tab } from "./types";
-<<<<<<< HEAD
->>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
-=======
-import MaskGroup from "@/assets/home/Mask group.svg";
->>>>>>> e6c6a31 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
 
 export default function Home() {
-	const [activeTab, setActiveTab] = useState<Tab>("home");
-	const [_navHeight, setNavHeight] = useState(0);
-	const navRef = useRef<HTMLElement>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('home');
+  const [_navHeight, setNavHeight] = useState(0);
+  const navRef = useRef<HTMLElement>(null);
 
-	const handleTabClick = (tabName: Tab) => {
-		setActiveTab(tabName);
-	};
+  const handleTabClick = (tabName: Tab) => {
+    setActiveTab(tabName);
+  };
 
-<<<<<<< HEAD
   useEffect(() => {
     if (navRef.current) {
       setNavHeight(navRef.current.offsetHeight);
     }
   }, []);
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
+
   return (
-    <main className="min-w-[3.75rem] min-h-screen text-white relative px-4 pb-20 bg-gradient-to-br from-[#140927] via-[#403397] to-[#4665F3]">
-      {/* Radial gradient 배경 */}
-      <div className="absolute inset-0 opacity-60">
-        <Image
-          src={MaskGroup}
-          alt="배경 그라디언트"
-          className="w-full h-full object-cover"
-          priority
-        />
-      </div>
-      {/* 콘텐츠 영역 */}
-      <div className="relative z-10">
-        <section className="flex justify-between font-bold text-h3 pt-[71px]">
-          <span>Logo</span>
-          {/* NOTE(yubin):아이콘 교체 */}
-          <Bell />
-        </section>
-        <section className="text-h2 mt-[2.2rem]">
-          <h1>
-            유빈님, 반가워요!
-            <br />
-            오늘의 기록을 시작할까요?
-          </h1>
-          <p className="text-gray-500 text-sm mt-2">
-            또잇이와 함께 배아픈 이유를 찾아보아요
-          </p>
-        </section>
-        {/* 중앙 아이콘 영역 */}
-        <section className="flex justify-center items-center mt-[2.94rem]">
-          {/* NOTE(yubin):이미지 교체 */}
+    <>
+      <main className="min-w-[3.75rem] min-h-screen text-white relative px-4 pb-20 bg-gradient-to-br from-[#140927] via-[#403397] to-[#4665F3]">
+        {/* Radial gradient 배경 */}
+        <div className="absolute inset-0 opacity-70">
           <Image
-            width={213}
-            height={206}
-            src={'https://placehold.co/600x400.png'}
-            alt="홈 화면 중앙 아이콘"
+            src={MaskGroup}
+            alt="배경 그라디언트"
+            className="w-full h-full object-cover"
+            priority
           />
-<<<<<<< HEAD
-        </section>
-      </div>
-    </main>
-=======
         </div>
         {/* 콘텐츠 영역 */}
         <div className="relative z-10">
@@ -125,64 +72,5 @@ export default function Home() {
         currentTab={activeTab}
       />
     </>
->>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
   );
-=======
-	useEffect(() => {
-		if (navRef.current) {
-			setNavHeight(navRef.current.offsetHeight);
-		}
-	}, []);
-	return (
-		<>
-			<main className="min-w-[3.75rem] min-h-screen text-white relative px-4 pb-20 bg-gradient-to-br from-[#140927] via-[#403397] to-[#4665F3]">
-				{/* Radial gradient 배경 */}
-				<div className="absolute inset-0 opacity-70">
-					<Image
-						src={MaskGroup}
-						alt="배경 그라디언트"
-						className="w-full h-full object-cover"
-						priority
-					/>
-				</div>
-				{/* 콘텐츠 영역 */}
-				<div className="relative z-10">
-					<section className="flex justify-between font-bold text-h3 pt-[71px]">
-						<span>Logo</span>
-						{/* NOTE(yubin):아이콘 교체 */}
-						<Bell />
-					</section>
-					<section className="text-h2 mt-[2.2rem]">
-						<h1>
-							유빈님, 반가워요!
-							<br />
-							오늘의 기록을 시작할까요?
-						</h1>
-						<p className="text-gray-500 text-sm mt-2">
-							또잇이와 함께 배아픈 이유를 찾아보아요
-						</p>
-					</section>
-					{/* 중앙 아이콘 영역 */}
-					<section className="flex justify-center items-center mt-[2.94rem]">
-						{/* NOTE(yubin):이미지 교체 */}
-						<Image
-							width={213}
-							height={206}
-							src={"https://placehold.co/600x400.png"}
-							alt="홈 화면 중앙 아이콘"
-						/>
-					</section>
-				</div>
-			</main>
-			{/* 기록하기 영역 */}
-			{/* <RecordSection navHeight={navHeight} /> */}
-			{/* 하단 내비게이션 바*/}
-			<BottomNavigation
-				navRef={navRef}
-				onTabClick={handleTabClick}
-				currentTab={activeTab}
-			/>
-		</>
-	);
->>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 }

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -2,9 +2,31 @@
 
 import { Bell } from 'lucide-react';
 import Image from 'next/image';
+<<<<<<< HEAD
 import MaskGroup from '@/assets/home/Mask group.svg';
 
 export default function Home() {
+=======
+import { useEffect, useRef, useState } from 'react';
+import { BottomNavigation } from './_components/ui';
+import type { Tab } from './types';
+import MaskGroup from '@/assets/home/Mask group.svg';
+
+export default function Home() {
+  const [activeTab, setActiveTab] = useState<Tab>('home');
+  const [_navHeight, setNavHeight] = useState(0);
+  const navRef = useRef<HTMLElement>(null);
+
+  const handleTabClick = (tabName: Tab) => {
+    setActiveTab(tabName);
+  };
+
+  useEffect(() => {
+    if (navRef.current) {
+      setNavHeight(navRef.current.offsetHeight);
+    }
+  }, []);
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
   return (
     <main className="min-w-[3.75rem] min-h-screen text-white relative px-4 pb-20 bg-gradient-to-br from-[#140927] via-[#403397] to-[#4665F3]">
       {/* Radial gradient 배경 */}
@@ -42,8 +64,50 @@ export default function Home() {
             src={'https://placehold.co/600x400.png'}
             alt="홈 화면 중앙 아이콘"
           />
+<<<<<<< HEAD
         </section>
       </div>
     </main>
+=======
+        </div>
+        {/* 콘텐츠 영역 */}
+        <div className="relative z-10">
+          <section className="flex justify-between font-bold text-h3 pt-[71px]">
+            <span>Logo</span>
+            {/* NOTE(yubin):아이콘 교체 */}
+            <Bell />
+          </section>
+          <section className="text-h2 mt-[2.2rem]">
+            <h1>
+              유빈님, 반가워요!
+              <br />
+              오늘의 기록을 시작할까요?
+            </h1>
+            <p className="text-gray-500 text-sm mt-2">
+              또잇이와 함께 배아픈 이유를 찾아보아요
+            </p>
+          </section>
+          {/* 중앙 아이콘 영역 */}
+          <section className="flex justify-center items-center mt-[2.94rem]">
+            {/* NOTE(yubin):이미지 교체 */}
+            <Image
+              width={213}
+              height={206}
+              src={'https://placehold.co/600x400.png'}
+              alt="홈 화면 중앙 아이콘"
+            />
+          </section>
+        </div>
+      </main>
+      {/* 기록하기 영역 */}
+      {/* <RecordSection navHeight={navHeight} /> */}
+      {/* 하단 내비게이션 바*/}
+      <BottomNavigation
+        navRef={navRef}
+        onTabClick={handleTabClick}
+        currentTab={activeTab}
+      />
+    </>
+>>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
   );
 }

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -1,5 +1,6 @@
-'use client';
+"use client";
 
+<<<<<<< HEAD
 import { Bell } from 'lucide-react';
 import Image from 'next/image';
 <<<<<<< HEAD
@@ -11,16 +12,25 @@ import { useEffect, useRef, useState } from 'react';
 import { BottomNavigation } from './_components/ui';
 import type { Tab } from './types';
 import MaskGroup from '@/assets/home/Mask group.svg';
+=======
+import { Bell } from "lucide-react";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+import MaskGroup from "@/assets/home/Mask group.svg";
+import { BottomNavigation } from "./_components/ui";
+import type { Tab } from "./types";
+>>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState<Tab>('home');
-  const [_navHeight, setNavHeight] = useState(0);
-  const navRef = useRef<HTMLElement>(null);
+	const [activeTab, setActiveTab] = useState<Tab>("home");
+	const [_navHeight, setNavHeight] = useState(0);
+	const navRef = useRef<HTMLElement>(null);
 
-  const handleTabClick = (tabName: Tab) => {
-    setActiveTab(tabName);
-  };
+	const handleTabClick = (tabName: Tab) => {
+		setActiveTab(tabName);
+	};
 
+<<<<<<< HEAD
   useEffect(() => {
     if (navRef.current) {
       setNavHeight(navRef.current.offsetHeight);
@@ -110,4 +120,62 @@ export default function Home() {
     </>
 >>>>>>> feccaa5 (fix: RecordSection import 경로 수정 및 사용하지 않는 변수 정리)
   );
+=======
+	useEffect(() => {
+		if (navRef.current) {
+			setNavHeight(navRef.current.offsetHeight);
+		}
+	}, []);
+	return (
+		<>
+			<main className="min-w-[3.75rem] min-h-screen text-white relative px-4 pb-20 bg-gradient-to-br from-[#140927] via-[#403397] to-[#4665F3]">
+				{/* Radial gradient 배경 */}
+				<div className="absolute inset-0 opacity-70">
+					<Image
+						src={MaskGroup}
+						alt="배경 그라디언트"
+						className="w-full h-full object-cover"
+						priority
+					/>
+				</div>
+				{/* 콘텐츠 영역 */}
+				<div className="relative z-10">
+					<section className="flex justify-between font-bold text-h3 pt-[71px]">
+						<span>Logo</span>
+						{/* NOTE(yubin):아이콘 교체 */}
+						<Bell />
+					</section>
+					<section className="text-h2 mt-[2.2rem]">
+						<h1>
+							유빈님, 반가워요!
+							<br />
+							오늘의 기록을 시작할까요?
+						</h1>
+						<p className="text-gray-500 text-sm mt-2">
+							또잇이와 함께 배아픈 이유를 찾아보아요
+						</p>
+					</section>
+					{/* 중앙 아이콘 영역 */}
+					<section className="flex justify-center items-center mt-[2.94rem]">
+						{/* NOTE(yubin):이미지 교체 */}
+						<Image
+							width={213}
+							height={206}
+							src={"https://placehold.co/600x400.png"}
+							alt="홈 화면 중앙 아이콘"
+						/>
+					</section>
+				</div>
+			</main>
+			{/* 기록하기 영역 */}
+			{/* <RecordSection navHeight={navHeight} /> */}
+			{/* 하단 내비게이션 바*/}
+			<BottomNavigation
+				navRef={navRef}
+				onTabClick={handleTabClick}
+				currentTab={activeTab}
+			/>
+		</>
+	);
+>>>>>>> 1d431d7 (refactor: home-ui에서 BottomNavigation 관련 코드 제거)
 }


### PR DESCRIPTION
## 의도 🔍
- Home 페이지의 사용되는 `BottomNavigation`  마크업을 진행했습니다.

## 작업 결과 📸 (Optional)
<img width="499" height="92" alt="스크린샷 2025-09-16 오후 6 19 39" src="https://github.com/user-attachments/assets/c5f04473-7ff3-4168-9d03-1dc74a443597" />

