### PR TITLE
feat(web):RecordButton 컴포넌트 구현

### DIFF
--- a/web/src/app/home/_components/ui/RecordButton.tsx
+++ b/web/src/app/home/_components/ui/RecordButton.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import type { ButtonHTMLAttributes } from 'react';
+import poopIcon from '@/assets/home/poop.svg';
+
+type RecordButtonProps = {
+  title: string;
+  subtitle: string;
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'>;
+
+const RecordButton = ({
+  title,
+  subtitle,
+  ...buttonProps
+}: RecordButtonProps) => {
+  return (
+    <button
+      className="flex items-start bg-gray-800 flex-1 p-[1.12rem] rounded-[0.875rem] text-body3-r cursor-pointer"
+      type="button"
+      {...buttonProps}
+    >
+      <div className="text-left flex flex-col flex-1">
+        <div className="text-gray-400">{title}</div>
+        <div className="text-body1-sb">{subtitle}</div>
+        <div className="flex justify-end">
+          <Image src={poopIcon} alt="poop 아이콘" />
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default RecordButton;

--- a/web/src/app/home/_components/ui/RecordSection.tsx
+++ b/web/src/app/home/_components/ui/RecordSection.tsx
@@ -1,15 +1,19 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import ChevronLeft from '@/assets/home/IC_Chevron_Left.png';
 import ChevronRight from '@/assets/home/IC_Chevron_Right.png';
 import { cn } from '@/utils/utils-cn';
 import { formatDate, isNextDisabled, isPrevDisabled } from '../utils/util-date';
+import { getRecordPath } from '../utils/util-route';
+import RecordButton from './RecordButton';
 
 type RecordSectionProps = {
   navHeight: number;
 };
 
 const RecordSection = ({ navHeight }: RecordSectionProps) => {
+  const router = useRouter();
   const [selectedDate, setSelectedDate] = useState(new Date());
 
   const handleDateChange = (direction: 'prev' | 'next') => {
@@ -20,6 +24,10 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
       newDate.setDate(newDate.getDate() + 1);
     }
     setSelectedDate(newDate);
+  };
+  const handleRecordClick = (type: 'defecation' | 'lifestyle') => {
+    const path = getRecordPath(type, selectedDate);
+    router.push(path);
   };
 
   return (
@@ -58,8 +66,18 @@ const RecordSection = ({ navHeight }: RecordSectionProps) => {
           />
         </button>
       </div>
+      {/* RecordButton 컴포넌트는 record-button 브랜치에서 관리됩니다 */}
       <div className="flex gap-[0.69rem] mt-4">
-        {/* NOTE(yubin): RecordButton 컴포넌트 추가  */}
+        <RecordButton
+          title="이날의 뿡"
+          subtitle="배변 기록하기"
+          onClick={() => handleRecordClick('defecation')}
+        />
+        <RecordButton
+          title="이날의 냠"
+          subtitle="생활 기록하기"
+          onClick={() => handleRecordClick('lifestyle')}
+        />
       </div>
     </section>
   );

--- a/web/src/app/home/_components/ui/index.ts
+++ b/web/src/app/home/_components/ui/index.ts
@@ -1,2 +1,3 @@
 export { default as BottomNavigation } from './BottomNavigation';
+export { default as RecordButton } from './RecordButton';
 export { default as RecordSection } from './RecordSection';

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -4,12 +4,12 @@ import { Bell } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import MaskGroup from '@/assets/home/Mask group.svg';
-import { BottomNavigation } from './_components/ui';
+import { BottomNavigation, RecordSection } from './_components/ui';
 import type { Tab } from './types';
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState<Tab>('home');
-  const [_navHeight, setNavHeight] = useState(0);
+  const [navHeight, setNavHeight] = useState(0);
   const navRef = useRef<HTMLElement>(null);
 
   const handleTabClick = (tabName: Tab) => {
@@ -64,7 +64,7 @@ export default function Home() {
         </div>
       </main>
       {/* 기록하기 영역 */}
-      {/* <RecordSection navHeight={navHeight} /> */}
+      <RecordSection navHeight={navHeight} />
       {/* 하단 내비게이션 바*/}
       <BottomNavigation
         navRef={navRef}


### PR DESCRIPTION
## 의도 🔍
- Home에서 사용되는 `RecordButton` 컴포넌트를 구현했습니다.


## 작업 결과 📸 (Optional)
<img width="369" height="205" alt="스크린샷 2025-09-16 오후 6 54 42" src="https://github.com/user-attachments/assets/91ce217e-c769-451a-9cd2-fc797ed9040a" />

