### PR TITLE
feat(web): 배변 기록 유저 선택 값 미리보기 기능 작업

### DIFF
--- a/web/src/app/(record)/defecation/_components/constants/index.ts
+++ b/web/src/app/(record)/defecation/_components/constants/index.ts
@@ -29,24 +29,9 @@ export const DEFECATION_SHAPE = {
 	PORRIDGE: "죽",
 } as const satisfies Record<string, string>;
 
-// NOTE(taehyeon): 통증 정도에 대한 디테일 작업은 UI 확정 후 적용
-export const DEFECATION_PAIN = {
-	A: "0",
-	B: "10",
-	C: "20",
-	D: "30",
-	E: "40",
-	F: "50",
-	G: "60",
-	H: "70",
-	I: "80",
-	J: "90",
-	K: "100",
-} as const satisfies Record<string, string>;
-
 export const DEFECATION_TIME_TAKEN = {
 	LESS_THAN_5_MINUTES: "5분 내",
-	LESS_THAN_10_MINUTES: "10분 내",
+	LESS_THAN_10_MINUTES: "10분 이내",
 	MORE_THAN_10_MINUTES: "10분 이상",
 } as const satisfies Record<string, string>;
 

--- a/web/src/app/(record)/defecation/_components/providers/defecation-providers.tsx
+++ b/web/src/app/(record)/defecation/_components/providers/defecation-providers.tsx
@@ -16,9 +16,9 @@ export const DefecationProvider = ({
 			selectedTry: "",
 			selectedColor: "",
 			selectedShape: "",
-			selectedPain: 0,
+			selectedPain: -1,
 			selectedTimeTaken: "",
-			selectedOptional: "",
+			selectedOptional: "initial",
 		},
 		mode: "onChange",
 	});

--- a/web/src/app/(record)/defecation/_components/types/index.ts
+++ b/web/src/app/(record)/defecation/_components/types/index.ts
@@ -1,43 +1,37 @@
 import type {
-  DEFECATION_COLOR,
-  DEFECATION_DETAIL,
-  DEFECATION_PAIN,
-  DEFECATION_SHAPE,
-  DEFECATION_TIME_TAKEN,
-} from '../constants';
+	DEFECATION_COLOR,
+	DEFECATION_DETAIL,
+	DEFECATION_SHAPE,
+	DEFECATION_TIME_TAKEN,
+} from "../constants";
 
 // NOTE: 배변 기록 폼 타입
 export interface DefecationState {
-  selectedWhen: Date;
-  selectedTry: string;
-  selectedColor: string;
-  selectedShape: string;
-  selectedPain: string;
-  selectedTimeTaken: string;
-  selectedOptional: string;
+	selectedWhen: Date;
+	selectedTry: string;
+	selectedColor: string;
+	selectedShape: string;
+	selectedPain: string;
+	selectedTimeTaken: string;
+	selectedOptional: string;
 }
 
 // NOTE: 배변 기록 상세 타입
 export type DefecationTryDetailKey = keyof typeof DEFECATION_DETAIL;
 export type DefecationTryDetailValue =
-  (typeof DEFECATION_DETAIL)[DefecationTryDetailKey];
+	(typeof DEFECATION_DETAIL)[DefecationTryDetailKey];
 
 // NOTE: 배변 색상 타입
 export type DefecationTryColorKey = keyof typeof DEFECATION_COLOR;
 export type DefecationTryColorValue =
-  (typeof DEFECATION_COLOR)[DefecationTryColorKey];
+	(typeof DEFECATION_COLOR)[DefecationTryColorKey];
 
 // NOTE: 배변 모양 타입
 export type DefecationTryShapeKey = keyof typeof DEFECATION_SHAPE;
 export type DefecationTryShapeValue =
-  (typeof DEFECATION_SHAPE)[DefecationTryShapeKey];
-
-// NOTE: 배변 통증 타입 (TODO: 통증 정도에 대한 디테일 작업은 UI 확정 후 변경 필요)
-export type DefecationTryPainKey = keyof typeof DEFECATION_PAIN;
-export type DefecationTryPainValue =
-  (typeof DEFECATION_PAIN)[DefecationTryPainKey];
+	(typeof DEFECATION_SHAPE)[DefecationTryShapeKey];
 
 // NOTE: 배변 소요 시간 타입
 export type DefecationTryTimeTakenKey = keyof typeof DEFECATION_TIME_TAKEN;
 export type DefecationTryTimeTakenValue =
-  (typeof DEFECATION_TIME_TAKEN)[DefecationTryTimeTakenKey];
+	(typeof DEFECATION_TIME_TAKEN)[DefecationTryTimeTakenKey];

--- a/web/src/app/(record)/defecation/_components/ui/common/collapsible-toggle.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/common/collapsible-toggle.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/utils/utils-cn";
 interface CollapsibleToggleProps {
 	id: string;
 	trigger: ReactNode;
+	previewr: ReactNode;
 	children: ReactNode;
 	className?: string;
 	isOpen: boolean;
@@ -16,6 +17,7 @@ interface CollapsibleToggleProps {
 export function CollapsibleToggle({
 	id,
 	trigger,
+	previewr,
 	children,
 	className,
 	isOpen,
@@ -37,12 +39,15 @@ export function CollapsibleToggle({
 				aria-controls={`collapsible-content-${id}`}
 			>
 				{trigger}
-				<ChevronThinIcon
-					type={isOpen ? "up" : "down"}
-					className={cn(
-						"will-change-transform transition-transform duration-300 text-white",
-					)}
-				/>
+				<div className="flex items-center justify-center gap-3.5">
+					{previewr}
+					<ChevronThinIcon
+						type={isOpen ? "up" : "down"}
+						className={cn(
+							"will-change-transform transition-transform duration-300 text-white",
+						)}
+					/>
+				</div>
 			</button>
 			<div
 				id={`collapsible-content-${id}`}

--- a/web/src/app/(record)/defecation/_components/ui/defecation-detail.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/defecation-detail.tsx
@@ -11,6 +11,7 @@ import {
 	DefecationPain,
 	DefecationShape,
 	DefecationTimeTaken,
+	SelectPreview,
 } from "./select-defecation";
 
 export const DefecationDetail = () => {
@@ -52,6 +53,10 @@ export const DefecationDetail = () => {
 		() => handleSectionChange("OPTIONAL"),
 		[handleSectionChange],
 	);
+	const onOptionalSelect = useCallback(
+		() => handleSectionChange(null),
+		[handleSectionChange],
+	);
 
 	const renderSelectSection = (value: DefecationTryDetailKey) => {
 		switch (value) {
@@ -64,7 +69,12 @@ export const DefecationDetail = () => {
 			case "TIME_TAKEN":
 				return <DefecationTimeTaken onTimeTakenSelect={onTimeTakenSelect} />;
 			case "OPTIONAL":
-				return <DefecationOptional isOpen={openId === "OPTIONAL"} />;
+				return (
+					<DefecationOptional
+						isOpen={openId === "OPTIONAL"}
+						onOptionalSelect={onOptionalSelect}
+					/>
+				);
 			default:
 				return <DefecationColor />;
 		}
@@ -80,6 +90,7 @@ export const DefecationDetail = () => {
 						onToggle={() => {
 							handleToggle(key as DefecationTryDetailKey);
 						}}
+						previewr={<SelectPreview currentKey={key} />}
 						trigger={<p className="text-button-1">{value}</p>}
 					>
 						<div>{renderSelectSection(key as DefecationTryDetailKey)}</div>

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/index.ts
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/index.ts
@@ -1,5 +1,6 @@
-export { default as DefecationColor } from './color';
-export { default as DefecationOptional } from './optional';
-export { default as DefecationPain } from './pain';
-export { default as DefecationShape } from './shape';
-export { default as DefecationTimeTaken } from './time-taken';
+export { default as DefecationColor } from "./color";
+export { default as DefecationOptional } from "./optional";
+export { default as DefecationPain } from "./pain";
+export { default as SelectPreview } from "./preview";
+export { default as DefecationShape } from "./shape";
+export { default as DefecationTimeTaken } from "./time-taken";

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/optional.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/optional.tsx
@@ -5,8 +5,15 @@ import { useFormContext } from "react-hook-form";
 import { DeleteIcon } from "@/components";
 import type { DefecationFormValues } from "../../schemas";
 
-export default function Optional({ isOpen }: { isOpen: boolean }) {
-	const { register } = useFormContext<DefecationFormValues>();
+export default function Optional({
+	isOpen,
+	onOptionalSelect,
+}: {
+	isOpen: boolean;
+	onOptionalSelect?: () => void;
+}) {
+	const { register, setValue, getValues } =
+		useFormContext<DefecationFormValues>();
 	const { ref, ...rest } = register("selectedOptional");
 
 	const [showDelete, setShowDelete] = useState(false);
@@ -14,9 +21,14 @@ export default function Optional({ isOpen }: { isOpen: boolean }) {
 
 	useEffect(() => {
 		if (isOpen && inputRef.current) {
+			const currentValue = getValues("selectedOptional");
+			if (currentValue === "initial") {
+				inputRef.current.value = "";
+			}
 			inputRef.current.focus();
+			setShowDelete(inputRef.current.value.length > 0);
 		}
-	}, [isOpen]);
+	}, [isOpen, getValues]);
 
 	return (
 		<div>
@@ -34,7 +46,16 @@ export default function Optional({ isOpen }: { isOpen: boolean }) {
 					placeholder="ex. 출혈이 많이 났어요 (최대 30자)"
 					maxLength={30}
 					onChange={(e) => {
+						rest.onChange(e);
 						setShowDelete(e.target.value.length > 0);
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							setValue("selectedOptional", inputRef.current?.value, {
+								shouldValidate: true,
+							});
+							onOptionalSelect?.();
+						}
 					}}
 					className="w-full h-6 pb-2 pl-2 pr-6 bg-transparent border-b-[1px] border-b-white/30 text-sm font-normal focus:outline-none focus:border-b-white"
 				/>
@@ -48,7 +69,7 @@ export default function Optional({ isOpen }: { isOpen: boolean }) {
 							}
 							inputRef.current?.focus();
 							setShowDelete(false);
-							rest.onChange({ target: { value: "" } });
+							setValue("selectedOptional", "", { shouldDirty: true });
 						}}
 					>
 						<DeleteIcon className="text-gray-700" />

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/pain.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/pain.tsx
@@ -10,12 +10,14 @@ const DEBOUNCE_DELAY = 300;
 
 export default function Pain({ onPainSelect }: { onPainSelect?: () => void }) {
 	const { control, setValue } = useFormContext<DefecationFormValues>();
-	const [painValue, setPainValue] = useState(0);
+	const [painValue, setPainValue] = useState<number | null>(null);
 
 	const debouncedPainValue = useDebounce(painValue, DEBOUNCE_DELAY);
 
 	useEffect(() => {
-		setValue("selectedPain", debouncedPainValue, { shouldValidate: true });
+		setValue("selectedPain", debouncedPainValue ?? -1, {
+			shouldValidate: true,
+		});
 
 		if (debouncedPainValue) {
 			onPainSelect?.();
@@ -32,7 +34,10 @@ export default function Pain({ onPainSelect }: { onPainSelect?: () => void }) {
 					name="selectedPain"
 					control={control}
 					render={() => (
-						<DraggableProgressBar value={painValue} onChange={setPainValue} />
+						<DraggableProgressBar
+							value={painValue ?? 0}
+							onChange={setPainValue}
+						/>
 					)}
 				/>
 			</div>

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/preview.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/preview.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { cn } from "@/utils/utils-cn";
+import {
+	DEFECATION_COLOR,
+	DEFECATION_SHAPE,
+	DEFECATION_TIME_TAKEN,
+} from "../../constants";
+import type { DefecationFormValues } from "../../schemas";
+import type {
+	DefecationTryColorKey,
+	DefecationTryShapeKey,
+	DefecationTryTimeTakenKey,
+} from "../../types";
+
+export default function Preview({ currentKey }: { currentKey: string }) {
+	const { getValues } = useFormContext<DefecationFormValues>();
+
+	const handlePreview = useCallback(() => {
+		switch (currentKey) {
+			case "COLOR": {
+				const colorKey = getValues("selectedColor") as DefecationTryColorKey;
+				if (!colorKey || !DEFECATION_COLOR[colorKey]) {
+					return null;
+				}
+				const [_, colorCode] = DEFECATION_COLOR[colorKey];
+
+				return (
+					<div className="flex items-center gap-2">
+						<div
+							className="h-6.5 w-6.5 rounded-[6px]"
+							style={{ backgroundColor: colorCode }}
+						/>
+					</div>
+				);
+			}
+			case "SHAPE": {
+				const shapeKey = getValues("selectedShape") as DefecationTryShapeKey;
+				if (!shapeKey || !DEFECATION_SHAPE[shapeKey]) {
+					return null;
+				}
+				const shapeCode = DEFECATION_SHAPE[shapeKey];
+
+				return (
+					<div className="text-[13px] font-semibold rounded-[6px] bg-[#454551] py-1 px-2">
+						{shapeCode}
+					</div>
+				);
+			}
+			case "PAIN": {
+				const painKey = getValues("selectedPain");
+				if (painKey === -1) return null;
+
+				const calculatedPainCode = () => {
+					if (painKey >= 0 && painKey < 10) return "10";
+					else if (painKey >= 10 && painKey < 30) return "30";
+					else if (painKey >= 30 && painKey <= 50) return "50";
+					else if (painKey >= 50 && painKey <= 70) return "70";
+					else if (painKey >= 70 && painKey <= 100) return "100";
+					else return "0";
+				};
+
+				return (
+					<div
+						className={cn("text-[13px] font-semibold rounded-[6px] py-1 px-2", {
+							"bg-[#74CE7E]": calculatedPainCode() === "10",
+							"bg-[#8BB35F]": calculatedPainCode() === "30",
+							"bg-[#D6AC6A]": calculatedPainCode() === "50",
+							"bg-[#E98259]": calculatedPainCode() === "70",
+							"bg-[#FB5A58]": calculatedPainCode() === "100",
+						})}
+					>
+						{calculatedPainCode()}%
+					</div>
+				);
+			}
+			case "TIME_TAKEN": {
+				const timeTakenKey = getValues(
+					"selectedTimeTaken",
+				) as DefecationTryTimeTakenKey;
+				if (!timeTakenKey || !DEFECATION_TIME_TAKEN[timeTakenKey]) {
+					return null;
+				}
+				const timeTakenCode = DEFECATION_TIME_TAKEN[timeTakenKey];
+
+				return (
+					<div className="text-[13px] font-semibold rounded-[6px] bg-[#454551] py-1 px-2">
+						{timeTakenCode}
+					</div>
+				);
+			}
+			case "OPTIONAL": {
+				const optionalKey = getValues("selectedOptional");
+				if (optionalKey === "initial") return null;
+
+				return (
+					<div className="text-[13px] font-semibold rounded-[6px] bg-[#454551] py-1 px-2">
+						{optionalKey ? "메모 있음" : "메모 없음"}
+					</div>
+				);
+			}
+		}
+	}, [currentKey, getValues]);
+
+	useEffect(() => {
+		handlePreview();
+	}, [handlePreview]);
+
+	return <div>{handlePreview()}</div>;
+}

--- a/web/src/app/(record)/defecation/_components/ui/select-defecation/shape.tsx
+++ b/web/src/app/(record)/defecation/_components/ui/select-defecation/shape.tsx
@@ -41,7 +41,7 @@ export default function Shape({
 										field.onChange(key);
 										onShapeSelect?.();
 									}}
-									className="h-22 w-36.5 px-4 py-[13px]"
+									className="h-22 min-w-36.5 px-4 py-[13px]"
 								>
 									<div className="flex flex-col items-center justify-around gap-2">
 										{showType === "EMOJI"


### PR DESCRIPTION
## 의도 🔍
<!-- 해당 작업을 왜 하게 되었는지 이유를 작성합니다. -->
<!-- PRD 문서, 아사나, Figma, 노션, 슬랙 등의 컨텍스트가 있다면 링크를 첨부합니다. -->
배변 기록 시 유저가 선택한 값을 각 디테일 버튼 우측에 표기하는 기능을 추가합니다.


## 변경 사항 📝
<!-- 해당 작업이 어떤 변경사항을 포함하고 있는지 작성합니다. 변경사항이 의도에 포함되었다면 생략해도 됩니다. -->


## 작업 결과 📸 (Optional)
<!-- 변경 사항이 정상적으로 작동하는지 나타낼 수 있는 스크린샷이나 API 응답 등을 첨부합니다. -->
<img width="390" height="535" alt="스크린샷 2025-09-17 02 10 14" src="https://github.com/user-attachments/assets/5cc71f7b-b993-46e3-b3fc-4acfe3bfd257" />

