### PR TITLE
feat(web): 로그인 플로우 리다이렉트 경로 변경

### DIFF
--- a/web/src/app/auth/page.tsx
+++ b/web/src/app/auth/page.tsx
@@ -29,7 +29,7 @@ const KAKAO_LOGIN_INITIATE_URL = `${API_BASE}${API_ENDPOINTS.AUTH.KAKAO_LOGIN}`;
 function AuthContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [error, setErroror] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const redirectUri = useMemo(() => {
     if (typeof window === 'undefined') return '';
@@ -68,7 +68,7 @@ function AuthContent() {
 
   useEffect(() => {
     const error = searchParams.get('erroror_message');
-    if (error) setErroror(decodeURIComponent(error));
+    if (error) setError(decodeURIComponent(error));
   }, [searchParams]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## 의도 🔍
- 로그인 진행 시 리다이렉트 경로를 변경합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 리다이렉트 URI를 현재 도메인(origin) 기준으로 자동 설정하고 폼에 반영.
  - 인증 콜백 파라미터 존재 시 렌더를 건너뛰는 사전 검사 추가로 전환 매끄러움 향상.
  - 라우팅 훅을 활용해 초기 인증 흐름과 리다이렉트 처리 강화.

- 버그 수정
  - 인증 완료 후 주소창의 임시 인증 파라미터를 자동 제거하여 깔끔한 URL 유지.
  - 초기 인증 처리 시 화면 깜빡임 최소화 및 오류 처리 개선.

- 리팩터링
  - 토큰 갱신 로직 정비: 현재 액세스 토큰이 없을 때만 백그라운드 갱신 시도하고, 발급 시 자동 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->